### PR TITLE
feat: add MIT License for open source distribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 ibourgeois
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. 


### PR DESCRIPTION
**Title**: feat: add MIT License for open source distribution

**Description**: 
- Added standard MIT License file to the project root
- Copyright (c) 2025 ibourgeois
- Enables open source distribution and contribution
- Fulfills the license reference in the README.md documentation
- Standard MIT License format with proper copyright notice

**Benefits**:
- Clear licensing terms for contributors and users
- Enables commercial use, modification, and distribution
- Provides liability protection for the project maintainer
- Standard open source license that's widely recognized
- Required for proper open source project documentation

**License Features**:
- Permits commercial use
- Permits modification
- Permits distribution
- Permits private use
- Includes liability limitation
- Includes warranty disclaimer

**Files Added**:
-  - MIT License file in project root